### PR TITLE
Add PEP 8 style check workflow

### DIFF
--- a/.github/workflows/pep8-check.yml
+++ b/.github/workflows/pep8-check.yml
@@ -1,0 +1,25 @@
+name: PEP 8 Style Check
+
+on: [push, pull_request]
+
+jobs:
+  flake8-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.12.4'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+
+      - name: Run flake8
+        run: |
+          flake8 .


### PR DESCRIPTION
This commit adds a new GitHub workflow to enforce PEP 8 style guide. The workflow will be triggered on every push and pull request and will use flake8 for linting.

Tested locally with act [https://github.com/nektos/act](url)
![act-output](https://github.com/user-attachments/assets/6615e790-a112-4e93-9d81-cae26e653811)

output from 
`act -n`


