### PR TITLE
Filter out organizations that cannot be used for sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ claude.sync
 config.json
 claudesync.log
 chats
+some_value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claudesync"
-version = "0.3.9"
+version = "0.4.0"
 authors = [
     {name = "Jahziah Wagner", email = "jahziah.wagner+pypi@gmail.com"},
 ]

--- a/src/claudesync/cli/organization.py
+++ b/src/claudesync/cli/organization.py
@@ -13,13 +13,15 @@ def organization():
 @click.pass_obj
 @handle_errors
 def ls(config):
-    """List all available organizations."""
+    """List all available organizations with required capabilities."""
     provider = validate_and_get_provider(config, require_org=False)
     organizations = provider.get_organizations()
     if not organizations:
-        click.echo("No organizations found.")
+        click.echo(
+            "No organizations with required capabilities (chat and claude_pro) found."
+        )
     else:
-        click.echo("Available organizations:")
+        click.echo("Available organizations with required capabilities:")
         for idx, org in enumerate(organizations, 1):
             click.echo(f"  {idx}. {org['name']} (ID: {org['id']})")
 
@@ -32,9 +34,11 @@ def select(config):
     provider = validate_and_get_provider(config, require_org=False)
     organizations = provider.get_organizations()
     if not organizations:
-        click.echo("No organizations found.")
+        click.echo(
+            "No organizations with required capabilities (chat and claude_pro) found."
+        )
         return
-    click.echo("Available organizations:")
+    click.echo("Available organizations with required capabilities:")
     for idx, org in enumerate(organizations, 1):
         click.echo(f"  {idx}. {org['name']} (ID: {org['id']})")
     selection = click.prompt("Enter the number of the organization to select", type=int)

--- a/src/claudesync/providers/base_claude_ai.py
+++ b/src/claudesync/providers/base_claude_ai.py
@@ -33,7 +33,11 @@ class BaseClaudeAIProvider(BaseProvider):
         response = self._make_request("GET", "/organizations")
         if not response:
             raise ProviderError("Unable to retrieve organization information")
-        return [{"id": org["uuid"], "name": org["name"]} for org in response]
+        return [
+            {"id": org["uuid"], "name": org["name"]}
+            for org in response
+            if set(["chat", "claude_pro"]).issubset(set(org.get("capabilities", [])))
+        ]
 
     def get_projects(self, organization_id, include_archived=False):
         response = self._make_request(

--- a/tests/cli/test_organization.py
+++ b/tests/cli/test_organization.py
@@ -14,8 +14,16 @@ class TestOrganizationCLI(unittest.TestCase):
         # Mock the provider
         mock_provider = MagicMock()
         mock_provider.get_organizations.return_value = [
-            {"id": "org1", "name": "Organization 1"},
-            {"id": "org2", "name": "Organization 2"},
+            {
+                "id": "org1",
+                "name": "Organization 1",
+                "capabilities": ["chat", "claude_pro"],
+            },
+            {
+                "id": "org2",
+                "name": "Organization 2",
+                "capabilities": ["chat", "claude_pro"],
+            },
         ]
         mock_validate_and_get_provider.return_value = mock_provider
 
@@ -29,7 +37,10 @@ class TestOrganizationCLI(unittest.TestCase):
         mock_provider.get_organizations.return_value = []
         result = self.runner.invoke(cli, ["organization", "ls"])
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("No organizations found.", result.output)
+        self.assertIn(
+            "No organizations with required capabilities (chat and claude_pro) found.",
+            result.output,
+        )
 
         # Test error handling
         mock_validate_and_get_provider.side_effect = ConfigurationError(
@@ -45,8 +56,16 @@ class TestOrganizationCLI(unittest.TestCase):
         # Mock the provider
         mock_provider = MagicMock()
         mock_provider.get_organizations.return_value = [
-            {"id": "org1", "name": "Organization 1"},
-            {"id": "org2", "name": "Organization 2"},
+            {
+                "id": "org1",
+                "name": "Organization 1",
+                "capabilities": ["chat", "claude_pro"],
+            },
+            {
+                "id": "org2",
+                "name": "Organization 2",
+                "capabilities": ["chat", "claude_pro"],
+            },
         ]
         mock_validate_and_get_provider.return_value = mock_provider
 
@@ -68,7 +87,10 @@ class TestOrganizationCLI(unittest.TestCase):
         mock_provider.get_organizations.return_value = []
         result = self.runner.invoke(cli, ["organization", "select"])
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("No organizations found.", result.output)
+        self.assertIn(
+            "No organizations with required capabilities (chat and claude_pro) found.",
+            result.output,
+        )
 
         # Test error handling
         mock_validate_and_get_provider.side_effect = ProviderError("Provider error")


### PR DESCRIPTION
We only want to show organizations for claude.ai, not api.claude.ai