### PR TITLE
fix: ignore fail via .gitignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claudesync"
-version = "0.4.0"
+version = "0.4.2"
 authors = [
     {name = "Jahziah Wagner", email = "jahziah.wagner+pypi@gmail.com"},
 ]

--- a/src/claudesync/utils.py
+++ b/src/claudesync/utils.py
@@ -94,7 +94,7 @@ def compute_md5_hash(content):
     return hashlib.md5(content.encode("utf-8")).hexdigest()
 
 
-def should_process_file(file_path, filename, gitignore):
+def should_process_file(file_path, filename, gitignore, base_path):
     """
     Determines whether a file should be processed based on various criteria.
 
@@ -109,6 +109,7 @@ def should_process_file(file_path, filename, gitignore):
         file_path (str): The full path to the file.
         filename (str): The name of the file.
         gitignore (pathspec.PathSpec or None): A PathSpec object containing .gitignore patterns, if available.
+        base_path (str): The base directory path of the project.
 
     Returns:
         bool: True if the file should be processed, False otherwise.
@@ -123,8 +124,10 @@ def should_process_file(file_path, filename, gitignore):
         return False
 
     # Use gitignore rules if available
-    if gitignore and gitignore.match_file(file_path):
-        return False
+    if gitignore:
+        rel_path = os.path.relpath(file_path, base_path)
+        if gitignore.match_file(rel_path):
+            return False
 
     # Check if it's a text file
     return is_text_file(file_path)
@@ -187,7 +190,7 @@ def get_local_files(local_path):
             rel_path = os.path.join(rel_root, filename)
             full_path = os.path.join(root, filename)
 
-            if should_process_file(full_path, filename, gitignore):
+            if should_process_file(full_path, filename, gitignore, local_path):
                 file_hash = process_file(full_path)
                 if file_hash:
                     files[rel_path] = file_hash

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,23 +39,30 @@ class TestUtils(unittest.TestCase):
             with open(os.path.join(tmpdir, "subdir", "file3.txt"), "w") as f:
                 f.write("Content of file3")
 
-            # Create a .git file
+            # Create a test~ file
             for vcs in {".git", ".svn", ".hg", ".bzr", "_darcs", "CVS"}:
-                os.makedirs(os.path.join(tmpdir, vcs), exist_ok=True)
-                with open(os.path.join(tmpdir, vcs, ".gitignore"), "w") as f:
+                os.mkdir(os.path.join(tmpdir, vcs))
+                with open(os.path.join(tmpdir, vcs, "test~"), "w") as f:
                     f.write("*.log\n")
 
-            # Create a test~ file
-            with open(os.path.join(tmpdir, "test~"), "w") as f:
-                f.write("*.log\n")
+            for buildDir in {"target", "build"}:
+                os.mkdir(os.path.join(tmpdir, buildDir))
+                with open(os.path.join(tmpdir, buildDir, "output.txt"), "w") as f:
+                    f.write("Build output")
+
+            with open(os.path.join(tmpdir, ".gitignore"), "w") as f:
+                f.write("*.log\n/build\ntarget")
 
             local_files = get_local_files(tmpdir)
+            print(local_files)
 
             self.assertIn("file1.txt", local_files)
             self.assertIn("file2.py", local_files)
             self.assertIn(os.path.join("subdir", "file3.txt"), local_files)
+            self.assertNotIn(os.path.join("target", "output.txt"), local_files)
+            self.assertNotIn(os.path.join("build", "output.txt"), local_files)
             # Ensure ignored files not included
-            self.assertEqual(len(local_files), 3)
+            self.assertEqual(len(local_files), 4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
.gitignore of my web project
```
.gitignore
# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.

# dependencies
/node_modules
/.pnp
.pnp.js

# testing
/coverage

# production
/build
```

run `claudesync sync`, uploaded many files that should be ignored
```
Uploading new file node_modules/postcss-attribute-case-insensitive/LICENSE to remote...
Uploading new file node_modules/postcss-attribute-case-insensitive/CHANGELOG.md to remote...
Uploading new file node_modules/postcss-attribute-case-insensitive/README.md to remote...
Uploading new file node_modules/postcss-attribute-case-insensitive/package.json to remote...
Uploading new file node_modules/postcss-attribute-case-insensitive/dist/index.cjs to remote...
Uploading new file node_modules/postcss-attribute-case-insensitive/dist/index.mjs to remote...
Uploading new file node_modules/postcss-attribute-case-insensitive/dist/index.d.ts to remote...
...
```