### PR TITLE
Fix ClaudeSync 403 Error on Python 3.12.5 with Claude.ai

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claudesync"
-version = "0.5.0"
+version = "0.5.1"
 authors = [
     {name = "Jahziah Wagner", email = "jahziah.wagner+pypi@gmail.com"},
 ]
@@ -15,7 +15,6 @@ classifiers = [
 ]
 dependencies = [
     "Click>=8.1.7",
-    "requests>=2.32.3",
     "pathspec>=0.12.1",
     "crontab>=1.0.1",
     "click_completion>=0.5.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Click>=8.1.7
-requests>=2.32.3
 pathspec>=0.12.1
 crontab>=1.0.1
 click_completion>=0.5.2

--- a/src/claudesync/providers/base_claude_ai.py
+++ b/src/claudesync/providers/base_claude_ai.py
@@ -21,7 +21,7 @@ def _get_session_key_expiry():
         ) + datetime.timedelta(days=30)
         formatted_expires = default_expires.strftime(date_format).strip()
         expires = click.prompt(
-            "Please enter the expires time for the sessionKey",
+            "Please enter the expires time for the sessionKey (optional)",
             default=formatted_expires,
             type=str,
         ).strip()
@@ -71,7 +71,7 @@ class BaseClaudeAIProvider(BaseProvider):
         )
 
         while True:
-            session_key = click.prompt("Please enter your sessionKey", type=str)
+            session_key = click.prompt("Please enter your sessionKey", type=str, hide_input=True)
             if not session_key.startswith("sk-ant"):
                 click.echo(
                     "Invalid sessionKey format. Please make sure it starts with 'sk-ant'."

--- a/src/claudesync/providers/base_claude_ai.py
+++ b/src/claudesync/providers/base_claude_ai.py
@@ -71,7 +71,9 @@ class BaseClaudeAIProvider(BaseProvider):
         )
 
         while True:
-            session_key = click.prompt("Please enter your sessionKey", type=str, hide_input=True)
+            session_key = click.prompt(
+                "Please enter your sessionKey", type=str, hide_input=True
+            )
             if not session_key.startswith("sk-ant"):
                 click.echo(
                     "Invalid sessionKey format. Please make sure it starts with 'sk-ant'."
@@ -105,8 +107,10 @@ class BaseClaudeAIProvider(BaseProvider):
         return [
             {"id": org["uuid"], "name": org["name"]}
             for org in response
-            if ({"chat", "claude_pro"}.issubset(set(org.get("capabilities", []))) or
-                {"chat", "raven"}.issubset(set(org.get("capabilities", []))))
+            if (
+                {"chat", "claude_pro"}.issubset(set(org.get("capabilities", [])))
+                or {"chat", "raven"}.issubset(set(org.get("capabilities", [])))
+            )
         ]
 
     def get_projects(self, organization_id, include_archived=False):

--- a/src/claudesync/providers/claude_ai.py
+++ b/src/claudesync/providers/claude_ai.py
@@ -61,24 +61,7 @@ class ClaudeAIProvider(BaseClaudeAIProvider):
                 return json.loads(content_str)
 
         except urllib.error.HTTPError as e:
-            self.logger.error(f"Request failed: {str(e)}")
-            self.logger.error(f"Response status code: {e.code}")
-            self.logger.error(f"Response headers: {e.headers}")
-            content = e.read().decode("utf-8")
-            self.logger.error(f"Response content: {content}")
-
-            if e.code == 403:
-                error_msg = (
-                    "Received a 403 Forbidden error. Your session key might be invalid. "
-                    "Please try logging out and logging in again. If the issue persists, "
-                    "you can try using the claude.ai-curl provider as a workaround:\n"
-                    "claudesync api logout\n"
-                    "claudesync api login claude.ai-curl"
-                )
-                self.logger.error(error_msg)
-                raise ProviderError(error_msg)
-
-            raise ProviderError(f"API request failed: {str(e)}")
+            self.handle_http_error(e)
         except urllib.error.URLError as e:
             self.logger.error(f"URL Error: {str(e)}")
             raise ProviderError(f"API request failed: {str(e)}")
@@ -86,3 +69,21 @@ class ClaudeAIProvider(BaseClaudeAIProvider):
             self.logger.error(f"Failed to parse JSON response: {str(json_err)}")
             self.logger.error(f"Response content: {content_str}")
             raise ProviderError(f"Invalid JSON response from API: {str(json_err)}")
+
+    def handle_http_error(self, e):
+        self.logger.error(f"Request failed: {str(e)}")
+        self.logger.error(f"Response status code: {e.code}")
+        self.logger.error(f"Response headers: {e.headers}")
+        content = e.read().decode("utf-8")
+        self.logger.error(f"Response content: {content}")
+        if e.code == 403:
+            error_msg = (
+                "Received a 403 Forbidden error. Your session key might be invalid. "
+                "Please try logging out and logging in again. If the issue persists, "
+                "you can try using the claude.ai-curl provider as a workaround:\n"
+                "claudesync api logout\n"
+                "claudesync api login claude.ai-curl"
+            )
+            self.logger.error(error_msg)
+            raise ProviderError(error_msg)
+        raise ProviderError(f"API request failed: {str(e)}")

--- a/src/claudesync/providers/claude_ai.py
+++ b/src/claudesync/providers/claude_ai.py
@@ -6,6 +6,7 @@ import gzip
 from .base_claude_ai import BaseClaudeAIProvider
 from ..exceptions import ProviderError
 
+
 class ClaudeAIProvider(BaseClaudeAIProvider):
     def _make_request(self, method, endpoint, data=None):
         url = f"{self.BASE_URL}{endpoint}"
@@ -32,12 +33,12 @@ class ClaudeAIProvider(BaseClaudeAIProvider):
                 req.add_header(key, value)
 
             # Add cookies
-            cookie_string = '; '.join([f"{k}={v}" for k, v in cookies.items()])
-            req.add_header('Cookie', cookie_string)
+            cookie_string = "; ".join([f"{k}={v}" for k, v in cookies.items()])
+            req.add_header("Cookie", cookie_string)
 
             # Add data if present
             if data:
-                json_data = json.dumps(data).encode('utf-8')
+                json_data = json.dumps(data).encode("utf-8")
                 req.data = json_data
 
             # Make the request
@@ -46,12 +47,12 @@ class ClaudeAIProvider(BaseClaudeAIProvider):
                 self.logger.debug(f"Response headers: {response.headers}")
 
                 # Handle gzip encoding
-                if response.headers.get('Content-Encoding') == 'gzip':
+                if response.headers.get("Content-Encoding") == "gzip":
                     content = gzip.decompress(response.read())
                 else:
                     content = response.read()
 
-                content_str = content.decode('utf-8')
+                content_str = content.decode("utf-8")
                 self.logger.debug(f"Response content: {content_str[:1000]}...")
 
                 if not content:
@@ -63,7 +64,7 @@ class ClaudeAIProvider(BaseClaudeAIProvider):
             self.logger.error(f"Request failed: {str(e)}")
             self.logger.error(f"Response status code: {e.code}")
             self.logger.error(f"Response headers: {e.headers}")
-            content = e.read().decode('utf-8')
+            content = e.read().decode("utf-8")
             self.logger.error(f"Response content: {content}")
 
             if e.code == 403:

--- a/src/claudesync/providers/claude_ai.py
+++ b/src/claudesync/providers/claude_ai.py
@@ -1,31 +1,22 @@
+import urllib.request
+import urllib.error
+import urllib.parse
 import json
-import requests
+import gzip
 from .base_claude_ai import BaseClaudeAIProvider
 from ..exceptions import ProviderError
-
 
 class ClaudeAIProvider(BaseClaudeAIProvider):
     def _make_request(self, method, endpoint, data=None):
         url = f"{self.BASE_URL}{endpoint}"
         headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0",
-            "Origin": "https://claude.ai",
-            "Referer": "https://claude.ai/projects",
-            "Accept": "*/*",
-            "Accept-Encoding": "gzip, deflate, zstd",
-            "Accept-Language": "en-US,en;q=0.5",
-            "anthropic-client-sha": "unknown",
-            "anthropic-client-version": "unknown",
-            "Connection": "keep-alive",
-            "Sec-Fetch-Dest": "empty",
-            "Sec-Fetch-Mode": "cors",
-            "Sec-Fetch-Site": "same-origin",
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:129.0) Gecko/20100101 Firefox/129.0",
+            "Content-Type": "application/json",
+            "Accept-Encoding": "gzip",
         }
 
         cookies = {
             "sessionKey": self.session_key,
-            "CH-prefers-color-scheme": "dark",
-            "anthropic-consent-preferences": '{"analytics":true,"marketing":true}',
         }
 
         try:
@@ -35,15 +26,47 @@ class ClaudeAIProvider(BaseClaudeAIProvider):
             if data:
                 self.logger.debug(f"Request data: {data}")
 
-            response = requests.request(
-                method, url, headers=headers, cookies=cookies, json=data
-            )
+            # Prepare the request
+            req = urllib.request.Request(url, method=method)
+            for key, value in headers.items():
+                req.add_header(key, value)
 
-            self.logger.debug(f"Response status code: {response.status_code}")
-            self.logger.debug(f"Response headers: {response.headers}")
-            self.logger.debug(f"Response content: {response.text[:1000]}...")
+            # Add cookies
+            cookie_string = '; '.join([f"{k}={v}" for k, v in cookies.items()])
+            req.add_header('Cookie', cookie_string)
 
-            if response.status_code == 403:
+            # Add data if present
+            if data:
+                json_data = json.dumps(data).encode('utf-8')
+                req.data = json_data
+
+            # Make the request
+            with urllib.request.urlopen(req) as response:
+                self.logger.debug(f"Response status code: {response.status}")
+                self.logger.debug(f"Response headers: {response.headers}")
+
+                # Handle gzip encoding
+                if response.headers.get('Content-Encoding') == 'gzip':
+                    content = gzip.decompress(response.read())
+                else:
+                    content = response.read()
+
+                content_str = content.decode('utf-8')
+                self.logger.debug(f"Response content: {content_str[:1000]}...")
+
+                if not content:
+                    return None
+
+                return json.loads(content_str)
+
+        except urllib.error.HTTPError as e:
+            self.logger.error(f"Request failed: {str(e)}")
+            self.logger.error(f"Response status code: {e.code}")
+            self.logger.error(f"Response headers: {e.headers}")
+            content = e.read().decode('utf-8')
+            self.logger.error(f"Response content: {content}")
+
+            if e.code == 403:
                 error_msg = (
                     "Received a 403 Forbidden error. Your session key might be invalid. "
                     "Please try logging out and logging in again. If the issue persists, "
@@ -54,21 +77,11 @@ class ClaudeAIProvider(BaseClaudeAIProvider):
                 self.logger.error(error_msg)
                 raise ProviderError(error_msg)
 
-            response.raise_for_status()
-
-            if not response.content:
-                return None
-
-            return response.json()
-
-        except requests.RequestException as e:
-            self.logger.error(f"Request failed: {str(e)}")
-            if hasattr(e, "response") and e.response is not None:
-                self.logger.error(f"Response status code: {e.response.status_code}")
-                self.logger.error(f"Response headers: {e.response.headers}")
-                self.logger.error(f"Response content: {e.response.text}")
+            raise ProviderError(f"API request failed: {str(e)}")
+        except urllib.error.URLError as e:
+            self.logger.error(f"URL Error: {str(e)}")
             raise ProviderError(f"API request failed: {str(e)}")
         except json.JSONDecodeError as json_err:
             self.logger.error(f"Failed to parse JSON response: {str(json_err)}")
-            self.logger.error(f"Response content: {response.text}")
+            self.logger.error(f"Response content: {content_str}")
             raise ProviderError(f"Invalid JSON response from API: {str(json_err)}")

--- a/src/claudesync/utils.py
+++ b/src/claudesync/utils.py
@@ -194,10 +194,13 @@ def get_local_files(local_path):
 
         # Filter out directories before traversing
         dirs[:] = [
-            d for d in dirs
+            d
+            for d in dirs
             if d not in exclude_dirs
             and not (gitignore and gitignore.match_file(os.path.join(rel_root, d)))
-            and not (claudeignore and claudeignore.match_file(os.path.join(rel_root, d)))
+            and not (
+                claudeignore and claudeignore.match_file(os.path.join(rel_root, d))
+            )
         ]
 
         for filename in filenames:

--- a/tests/providers/test_base_claude_ai.py
+++ b/tests/providers/test_base_claude_ai.py
@@ -28,9 +28,9 @@ class TestBaseClaudeAIProvider(unittest.TestCase):
         mock_echo.assert_called()
 
         expected_calls = [
-            call("Please enter your sessionKey", type=str),
+            call("Please enter your sessionKey", type=str, hide_input=True),
             call(
-                "Please enter the expires time for the sessionKey",
+                "Please enter the expires time for the sessionKey (optional)",
                 default=ANY,
                 type=str,
             ),

--- a/tests/providers/test_claude_ai.py
+++ b/tests/providers/test_claude_ai.py
@@ -7,6 +7,7 @@ import gzip
 from claudesync.providers.claude_ai import ClaudeAIProvider
 from claudesync.exceptions import ProviderError
 
+
 class TestClaudeAIProvider(unittest.TestCase):
 
     def setUp(self):
@@ -20,8 +21,8 @@ class TestClaudeAIProvider(unittest.TestCase):
     def test_make_request_success(self, mock_urlopen, mock_get_session_key):
         mock_response = MagicMock()
         mock_response.status = 200
-        mock_response.headers = {'Content-Type': 'application/json'}
-        mock_response.read.return_value = json.dumps({"key": "value"}).encode('utf-8')
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.read.return_value = json.dumps({"key": "value"}).encode("utf-8")
         mock_urlopen.return_value.__enter__.return_value = mock_response
 
         mock_get_session_key.return_value = "sk-ant-1234"
@@ -45,11 +46,7 @@ class TestClaudeAIProvider(unittest.TestCase):
         mock_response.status = 403
         mock_response.read.return_value = b"Forbidden"
         mock_urlopen.side_effect = urllib.error.HTTPError(
-            url="http://test.com",
-            code=403,
-            msg="Forbidden",
-            hdrs={},
-            fp=None
+            url="http://test.com", code=403, msg="Forbidden", hdrs={}, fp=None
         )
 
         mock_get_session_key.return_value = "sk-ant-1234"
@@ -64,12 +61,15 @@ class TestClaudeAIProvider(unittest.TestCase):
     def test_make_request_gzip_response(self, mock_urlopen, mock_get_session_key):
         mock_response = MagicMock()
         mock_response.status = 200
-        mock_response.headers = {'Content-Type': 'application/json', 'Content-Encoding': 'gzip'}
+        mock_response.headers = {
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        }
 
         # Create gzipped content
-        content = json.dumps({"key": "gzipped_value"}).encode('utf-8')
+        content = json.dumps({"key": "gzipped_value"}).encode("utf-8")
         gzipped_content = BytesIO()
-        with gzip.GzipFile(fileobj=gzipped_content, mode='wb') as gzip_file:
+        with gzip.GzipFile(fileobj=gzipped_content, mode="wb") as gzip_file:
             gzip_file.write(content)
 
         mock_response.read.return_value = gzipped_content.getvalue()

--- a/tests/providers/test_claude_ai.py
+++ b/tests/providers/test_claude_ai.py
@@ -1,9 +1,11 @@
 import unittest
 from unittest.mock import patch, MagicMock
-import requests
+import urllib.error
+import json
+from io import BytesIO
+import gzip
 from claudesync.providers.claude_ai import ClaudeAIProvider
 from claudesync.exceptions import ProviderError
-
 
 class TestClaudeAIProvider(unittest.TestCase):
 
@@ -14,33 +16,41 @@ class TestClaudeAIProvider(unittest.TestCase):
         self.mock_config = MagicMock()
 
     @patch("claudesync.config_manager.ConfigManager.get_session_key")
-    @patch("claudesync.providers.claude_ai.requests.request")
-    def test_make_request_success(self, mock_request, mock_get_session_key):
+    @patch("claudesync.providers.claude_ai.urllib.request.urlopen")
+    def test_make_request_success(self, mock_urlopen, mock_get_session_key):
         mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"key": "value"}
-        mock_request.return_value = mock_response
+        mock_response.status = 200
+        mock_response.headers = {'Content-Type': 'application/json'}
+        mock_response.read.return_value = json.dumps({"key": "value"}).encode('utf-8')
+        mock_urlopen.return_value.__enter__.return_value = mock_response
 
         mock_get_session_key.return_value = "sk-ant-1234"
 
         result = self.provider._make_request("GET", "/test")
 
         self.assertEqual(result, {"key": "value"})
-        mock_request.assert_called_once()
+        mock_urlopen.assert_called_once()
 
-    @patch("claudesync.providers.claude_ai.requests.request")
-    def test_make_request_failure(self, mock_request):
-        mock_request.side_effect = requests.RequestException("Test error")
+    @patch("claudesync.providers.claude_ai.urllib.request.urlopen")
+    def test_make_request_failure(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.URLError("Test error")
 
         with self.assertRaises(ProviderError):
             self.provider._make_request("GET", "/test")
 
     @patch("claudesync.config_manager.ConfigManager.get_session_key")
-    @patch("claudesync.providers.claude_ai.requests.request")
-    def test_make_request_403_error(self, mock_request, mock_get_session_key):
+    @patch("claudesync.providers.claude_ai.urllib.request.urlopen")
+    def test_make_request_403_error(self, mock_urlopen, mock_get_session_key):
         mock_response = MagicMock()
-        mock_response.status_code = 403
-        mock_request.return_value = mock_response
+        mock_response.status = 403
+        mock_response.read.return_value = b"Forbidden"
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            url="http://test.com",
+            code=403,
+            msg="Forbidden",
+            hdrs={},
+            fp=None
+        )
 
         mock_get_session_key.return_value = "sk-ant-1234"
 
@@ -48,3 +58,26 @@ class TestClaudeAIProvider(unittest.TestCase):
             self.provider._make_request("GET", "/test")
 
         self.assertIn("403 Forbidden error", str(context.exception))
+
+    @patch("claudesync.config_manager.ConfigManager.get_session_key")
+    @patch("claudesync.providers.claude_ai.urllib.request.urlopen")
+    def test_make_request_gzip_response(self, mock_urlopen, mock_get_session_key):
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.headers = {'Content-Type': 'application/json', 'Content-Encoding': 'gzip'}
+
+        # Create gzipped content
+        content = json.dumps({"key": "gzipped_value"}).encode('utf-8')
+        gzipped_content = BytesIO()
+        with gzip.GzipFile(fileobj=gzipped_content, mode='wb') as gzip_file:
+            gzip_file.write(content)
+
+        mock_response.read.return_value = gzipped_content.getvalue()
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        mock_get_session_key.return_value = "sk-ant-1234"
+
+        result = self.provider._make_request("GET", "/test")
+
+        self.assertEqual(result, {"key": "gzipped_value"})
+        mock_urlopen.assert_called_once()


### PR DESCRIPTION
This update allows ClaudeSync to run with the provider Claude.ai on Python 3.12.5 by switching the HTTP client from requests to urllib.

```sh
$ python --version && claudesync api login claude.ai
Python 3.12.5
To obtain your session key, please follow these steps:
1. Open your web browser and go to https://claude.ai
2. Log in to your Claude account if you haven't already
3. Once logged in, open your browser's developer tools:
   - Chrome/Edge: Press F12 or Ctrl+Shift+I (Cmd+Option+I on Mac)
   - Firefox: Press F12 or Ctrl+Shift+I (Cmd+Option+I on Mac)
   - Safari: Enable developer tools in Preferences > Advanced, then press Cmd+Option+I
4. In the developer tools, go to the 'Application' tab (Chrome/Edge) or 'Storage' tab (Firefox)
5. In the left sidebar, expand 'Cookies' and select 'https://claude.ai'
6. Locate the cookie named 'sessionKey' and copy its value. Ensure that the value is not URL-encoded.
Please enter your sessionKey: 
Please enter the expires time for the sessionKey (optional) [Wed, 18 Sep 2024 15:32:03 UTC]: 
Logged in successfully.
...
$ claudesync project sync
Local → Remote: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 46/46 [00:43<00:00,  1.05it/s] 
Project sync completed successfully. 
```
