### PR TITLE
Add Black to GitHub Actions Workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
 name: Python package
 
 on:
@@ -28,7 +25,7 @@ jobs:
       run: |
         pip install -e .
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        python -m pip install flake8 pytest black
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
@@ -36,6 +33,9 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --max-complexity=10 --max-line-length=127 --statistics
+    - name: Format with Black
+      run: |
+        black --check --diff .
     - name: Test with pytest
       run: |
         pytest


### PR DESCRIPTION
# Add Black to GitHub Actions Workflow

This PR adds the Black code formatter to our GitHub Actions workflow. Here are the key changes:

1. **Install Black**: 
   In the "Install dependencies" step, we've added `black` to the list of packages installed:
   ```yaml
   python -m pip install flake8 pytest black
   ```

2. **New Black Formatting Step**:
   We've added a new step to run Black after linting with flake8 and before running tests:
   ```yaml
   - name: Format with Black
     run: |
       black --check --diff .
   ```

   This step runs Black in check mode (`--check`) and shows the diff of any formatting changes (`--diff`). 
   The workflow will fail if there are any formatting issues, but it won't actually change the files.

## Notes

- If we want Black to automatically format the files instead of just checking, we can remove the `--check` and `--diff` flags.
- Consider adding a `.black` configuration file to the repository to customize Black's behavior if needed.
- We might want to adjust our flake8 configuration to align with Black's formatting choices, particularly the line length.