### PR TITLE
fix: exclude ~/.claudesync from _find_local_config_dir results

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repo
+*       @jahwag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claudesync"
-version = "0.5.6"
+version = "0.5.7"
 authors = [
     {name = "Jahziah Wagner", email = "jahziah.wagner+pypi@gmail.com"},
 ]

--- a/src/claudesync/configmanager/file_config_manager.py
+++ b/src/claudesync/configmanager/file_config_manager.py
@@ -57,17 +57,19 @@ class FileConfigManager(BaseConfigManager):
         Finds the nearest directory containing a .claudesync folder.
 
         Searches from the current working directory upwards until it finds a .claudesync folder
-        or reaches the root directory.
+        or reaches the root directory. Excludes the ~/.claudesync directory.
 
         Returns:
             Path: The path containing the .claudesync folder, or None if not found.
         """
         current_dir = Path.cwd()
         root_dir = Path(current_dir.root)
+        home_dir = Path.home()
         depth = 0  # Initialize depth counter
 
         while current_dir != root_dir:
-            if (current_dir / ".claudesync").is_dir():
+            claudesync_dir = current_dir / ".claudesync"
+            if claudesync_dir.is_dir() and claudesync_dir != home_dir / ".claudesync":
                 return current_dir
 
             current_dir = current_dir.parent


### PR DESCRIPTION
- Add check to prevent ~/.claudesync from being returned as local config dir
- Update docstring to reflect new exclusion criteria
- Improve code review process and ownership clarity
