### PR TITLE
Fix/race condition in http server mock

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,15 @@
+import unittest
+
+from claudesync.configmanager.inmemory_config_manager import InMemoryConfigManager
+from tests.mock_http_server import SharedMockServer
+
+
+class BaseTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mock_server = SharedMockServer.get_instance()
+        cls.mock_server.start()
+
+    def setUp(self):
+        self.config = InMemoryConfigManager()
+        self.config.set("claude_api_url", "http://localhost:8000/api")

--- a/tests/test_chat_happy_path.py
+++ b/tests/test_chat_happy_path.py
@@ -1,25 +1,18 @@
+from typing import override
 import unittest
 import threading
 import time
 from click.testing import CliRunner
 from claudesync.cli.main import cli
 from claudesync.configmanager import InMemoryConfigManager
-from mock_http_server import run_mock_server
+from tests.test_base import BaseTestCase
 
 
-class TestChatHappyPath(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        # Start the mock server in a separate thread
-        cls.mock_server_thread = threading.Thread(target=run_mock_server)
-        cls.mock_server_thread.daemon = True
-        cls.mock_server_thread.start()
-        time.sleep(1)  # Give the server a moment to start
-
+class TestChatHappyPath(BaseTestCase):
+    @override
     def setUp(self):
+        super().setUp()
         self.runner = CliRunner()
-        self.config = InMemoryConfigManager()
-        self.config.set("claude_api_url", "http://localhost:8000/api")
 
     def test_chat_happy_path(self):
         # Step 1: Login

--- a/tests/test_chat_happy_path.py
+++ b/tests/test_chat_happy_path.py
@@ -1,10 +1,7 @@
 from typing import override
 import unittest
-import threading
-import time
 from click.testing import CliRunner
 from claudesync.cli.main import cli
-from claudesync.configmanager import InMemoryConfigManager
 from tests.test_base import BaseTestCase
 
 

--- a/tests/test_claude_ai.py
+++ b/tests/test_claude_ai.py
@@ -1,26 +1,17 @@
+from typing import override
 import unittest
-import threading
-import time
 from unittest.mock import patch
 from datetime import datetime
 
-from claudesync.configmanager import InMemoryConfigManager
 from claudesync.providers.claude_ai import ClaudeAIProvider
 from claudesync.exceptions import ProviderError
-from mock_http_server import run_mock_server
+from tests.test_base import BaseTestCase
 
 
-class TestClaudeAIProvider(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.mock_server_thread = threading.Thread(target=run_mock_server)
-        cls.mock_server_thread.daemon = True
-        cls.mock_server_thread.start()
-        time.sleep(1)
-
+class TestClaudeAIProvider(BaseTestCase):
+    @override
     def setUp(self):
-        self.config = InMemoryConfigManager()
-        self.config.set("claude_api_url", "http://127.0.0.1:8000/api")
+        super().setUp()
         self.provider = ClaudeAIProvider(self.config)
 
     def test_get_organizations(self):

--- a/tests/test_happy_path.py
+++ b/tests/test_happy_path.py
@@ -1,28 +1,16 @@
-import threading
-import time
+from typing import override
 import unittest
 from click.testing import CliRunner
 from unittest.mock import patch
 from claudesync.cli.main import cli
-from claudesync.configmanager import InMemoryConfigManager
-from mock_http_server import run_mock_server
+from tests.test_base import BaseTestCase
 
 
-class TestClaudeSyncHappyPath(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.mock_server_thread = threading.Thread(target=run_mock_server)
-        cls.mock_server_thread.daemon = True
-        cls.mock_server_thread.start()
-        time.sleep(1)  # Wait for the mock server to start
-
+class TestClaudeSyncHappyPath(BaseTestCase):
+    @override
     def setUp(self):
+        super().setUp()
         self.runner = CliRunner()
-        self.config = InMemoryConfigManager()
-        self.config.set(
-            "claude_api_url", "http://127.0.0.1:8000/api"
-        )  # Set BASE_URL for the mock server
 
     @patch("claudesync.utils.get_local_files")
     def test_happy_path(self, mock_get_local_files):


### PR DESCRIPTION
Hey there,

Thanks for this amazing project! I’m really loving ClaudeSync so far! As I was looking for the feature of `claudeignore` but apparently skimmed the documentation a bit too fast, I decided to quickly add the feature myself. While doing so, I discovered that the feature already exists 🤩.

Before I got started, though, I ran into some issues with the tests. At least for me, it appears there’s a race condition in the MockServer creation (as the Unit Tests run in parallel, leading to multiple threads trying to start a server on port 8000).

I’m not sure if this is the idiomatic way to resolve it for unit tests, but I gave it a shot. Feel free to take a look, and thanks again for creating this tool!

Cheers