### PR TITLE
Skip special files

### DIFF
--- a/src/claudesync/utils.py
+++ b/src/claudesync/utils.py
@@ -1,5 +1,6 @@
 import os
 import hashlib
+import stat
 from functools import wraps
 from pathlib import Path
 
@@ -229,6 +230,11 @@ def get_local_files(config, local_path, category=None, include_submodules=False)
         for filename in filenames:
             rel_path = os.path.join(rel_root, filename)
             full_path = os.path.join(root, filename)
+
+            st = os.lstat(full_path)
+            if not stat.S_ISREG(st.st_mode):
+                logger.debug(f"Skipping special file: {full_path}")
+                continue
 
             if spec.match_file(rel_path) and should_process_file(
                 config, full_path, filename, gitignore, local_path, claudeignore


### PR DESCRIPTION
I had a weird issue in this one repo of mine, where the sync just froze right at the start.  
I eventually figured out that was, because I have a special file in there. A named pipe to be exact.  
This is a quick fix to skip such files.  

This would unfortunately also skip symlinks, I believe. So if it is required to sync symlinks, or rather files under symlinks, as well, I could modify it to allow them.
