### PR TITLE
API domain swapped from api.claude.ai to claude.ai

### DIFF
--- a/embedding.txt
+++ b/embedding.txt
@@ -2884,7 +2884,7 @@ class BaseConfigManager(ABC):
             "max_file_size": 32 * 1024,
             "two_way_sync": False,
             "prune_remote_files": True,
-            "claude_api_url": "https://api.claude.ai/api",
+            "claude_api_url": "https://claude.ai/api",
             "compression_algorithm": "none",
             "submodule_detect_filenames": [
                 "pom.xml",
@@ -3293,7 +3293,7 @@ class BaseClaudeAIProvider(BaseProvider):
 
     @property
     def base_url(self):
-        return self.config.get("claude_api_url", "https://api.claude.ai/api")
+        return self.config.get("claude_api_url", "https://claude.ai/api")
 
     def _configure_logging(self):
         log_level = self.config.get("log_level", "INFO")

--- a/src/claudesync/configmanager/base_config_manager.py
+++ b/src/claudesync/configmanager/base_config_manager.py
@@ -38,7 +38,7 @@ class BaseConfigManager(ABC):
             "max_file_size": 32 * 1024,
             "two_way_sync": False,
             "prune_remote_files": True,
-            "claude_api_url": "https://api.claude.ai/api",
+            "claude_api_url": "https://claude.ai/api",
             "compression_algorithm": "none",
             "submodule_detect_filenames": [
                 "pom.xml",

--- a/src/claudesync/providers/base_claude_ai.py
+++ b/src/claudesync/providers/base_claude_ai.py
@@ -49,7 +49,7 @@ class BaseClaudeAIProvider(BaseProvider):
 
     @property
     def base_url(self):
-        return self.config.get("claude_api_url", "https://api.claude.ai/api")
+        return self.config.get("claude_api_url", "https://claude.ai/api")
 
     def _configure_logging(self):
         log_level = self.config.get("log_level", "INFO")


### PR DESCRIPTION
All requests in claude.ai chat follow to claude.ai/api for now
