### PR TITLE
simple dry run mode for push command

### DIFF
--- a/src/claudesync/cli/main.py
+++ b/src/claudesync/cli/main.py
@@ -100,9 +100,12 @@ def upgrade(ctx):
 @click.option(
     "--uberproject", is_flag=True, help="Include submodules in the parent project sync"
 )
+@click.option(
+    "--dryrun", is_flag=True, default=False, help="Just show what files would be sent"
+)
 @click.pass_obj
 @handle_errors
-def push(config, category, uberproject):
+def push(config, category, uberproject, dryrun):
     """Synchronize the project files, optionally including submodules in the parent project."""
     provider = validate_and_get_provider(config, require_project=True)
 
@@ -156,6 +159,12 @@ def push(config, category, uberproject):
             local_files = get_local_files(
                 config, local_path, category, include_submodules=False
             )
+
+        if dryrun:
+            for file in local_files.keys():
+                click.echo(f"Would send file: {file}")
+            click.echo("Not sending files due to dry run mode.")
+            return
 
         sync_manager.sync(local_files, remote_files)
         click.echo(


### PR DESCRIPTION
This PR adds a dry run option to the push command, so behaviour is

```
$ claudesync push --dryrun
Using default category: svelte_gir
sending file: vite.config.ts
sending file: package.json
...
sending file: src/services/girParser.ts
Not sending files due to dry run mode.

$ claudesync push 
Using default category: svelte_gir
Main project 'svelte_gir' synced successfully: https://claude.ai/project/01985aff-2911-7759-aaea-3ee7b94c5ce6
$ 

```

It's a simple implementation, and returns before processing the submodules. 


## Notes:

I think adding a more thorough dry run mode could be done by changing the options parsing, to pass global options overrides from click along with the config object in the context. but for my purposes (not using submodules) the above works for my case.
