### PR TITLE
fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Python package
 
 on:
@@ -5,7 +7,6 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
-
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jahwag/ClaudeSync/security/code-scanning/1](https://github.com/jahwag/ClaudeSync/security/code-scanning/1)

To resolve the issue, an explicit `permissions` block should be added to the workflow to limit the access granted to the `GITHUB_TOKEN`. Based on the tasks performed in the workflow (e.g., checking out code, installing dependencies, linting, formatting, and running tests), the `contents: read` permission is sufficient. This ensures that the workflow can read repository contents while preventing unnecessary write access.

The `permissions` block can be added at the workflow level (directly under the `name` field) to apply to all jobs, or at the job level (inside the `build` job) if different jobs in the workflow require distinct permissions. In this case, adding it at the workflow level is recommended for simplicity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
