### PR TITLE
fix: use PathSpec gitignore parser to remove deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claudesync"
-version = "0.7.6"
+version = "0.7.7"
 authors = [
     {name = "Jahziah Wagner", email = "540380+jahwag@users.noreply.github.com"},
 ]

--- a/src/claudesync/utils.py
+++ b/src/claudesync/utils.py
@@ -51,7 +51,7 @@ def load_gitignore(base_path):
     gitignore_path = os.path.join(base_path, ".gitignore")
     if os.path.exists(gitignore_path):
         with open(gitignore_path, "r") as f:
-            return pathspec.PathSpec.from_lines("gitwildmatch", f)
+            return pathspec.PathSpec.from_lines("gitignore", f)
     return None
 
 
@@ -201,7 +201,7 @@ def get_local_files(config, local_path, category=None, include_submodules=False)
     if category:
         patterns = categories[category]["patterns"]
 
-    spec = pathspec.PathSpec.from_lines("gitwildmatch", patterns)
+    spec = pathspec.PathSpec.from_lines("gitignore", patterns)
 
     submodules = config.get("submodules", [])
     submodule_paths = [sm["relative_path"] for sm in submodules]
@@ -366,7 +366,7 @@ def load_claudeignore(base_path):
     claudeignore_path = os.path.join(base_path, ".claudeignore")
     if os.path.exists(claudeignore_path):
         with open(claudeignore_path, "r") as f:
-            return pathspec.PathSpec.from_lines("gitwildmatch", f)
+            return pathspec.PathSpec.from_lines("gitignore", f)
     return None
 
 


### PR DESCRIPTION
## What changed
- Switched PathSpec parser mode from `gitwildmatch` to `gitignore` in three places in `src/claudesync/utils.py`:
  - `.gitignore` loading
  - category pattern matching in `get_local_files`
  - `.claudeignore` loading
- Bumped version in `pyproject.toml` from `0.7.6` to `0.7.7` (per project contribution requirements).

## Why
- Recent PathSpec versions deprecate `gitwildmatch` and emit warnings recommending `gitignore`.
- Using `gitignore` keeps matching behavior aligned with Git ignore semantics while removing avoidable deprecation noise during test runs.

## Testing
- ✅ `scripts/clone_and_test.sh jahwag/ClaudeSync` (pass)
- ✅ `source .venv/bin/activate && pytest -q` (28 passed)
